### PR TITLE
Adds Proxy-Script

### DIFF
--- a/src/module/Phpug/view/layout/layout.phtml
+++ b/src/module/Phpug/view/layout/layout.phtml
@@ -20,9 +20,9 @@ $this->headLink(array(
 $this->headScript()->appendFile($basePath . '/js/html5.js', 'text/javascript',
     array('conditional' => 'lt IE9',));
 
-$this->headScript()->appendFile($basePath . '/js/jquery-1.7.1.min.js');
-$this->headScript()->appendFile($basePath . '/js/jquery.cookie.js');
-$this->headScript()->appendFile($basePath . '/js/bootstrap.min.js');
+$this->headScript()->prependFile($basePath . '/js/bootstrap.min.js');
+$this->headScript()->prependFile($basePath . '/js/jquery.cookie.js');
+$this->headScript()->prependFile($basePath . '/js/jquery-1.7.1.min.js');
 $this->headScript()->appendScript('//<![CDATA[
 var pkBaseURL = (("https:" == document.location.protocol) ? "https://piwik.heigl.org/" : "http://piwik.heigl.org/");
 document.write(unescape("%3Cscript src=\'" + pkBaseURL + "piwik.js\' type=\'text/javascript\'%3E%3C/script%3E"));

--- a/src/public/.htaccess
+++ b/src/public/.htaccess
@@ -39,5 +39,7 @@ RewriteCond %{REQUEST_FILENAME} -s [OR]
 RewriteCond %{REQUEST_FILENAME} -l [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^.*$ - [NC,L]
-#RewriteRule ^(css|fonts|img|images|lib|js)/([^/]+)/(.*)$ %{DOCUMENT_ROOT}/../../vendor/$2/public/$1/$3
+
+RewriteRule ^(css|fonts|img|images|lib|js)/([^/]+)/(.*)$ proxy.php?module=$2&type=$1&file=$3 [NC,L]
+
 RewriteRule ^.*$ index.php [NC,L]

--- a/src/public/css/phpug
+++ b/src/public/css/phpug
@@ -1,1 +1,0 @@
-../../module/Phpug/public/css

--- a/src/public/fonts/phpug
+++ b/src/public/fonts/phpug
@@ -1,1 +1,0 @@
-../../module/Phpug/public/fonts

--- a/src/public/img/phpug
+++ b/src/public/img/phpug
@@ -1,1 +1,0 @@
-../../module/Phpug/public/img

--- a/src/public/js/phpug
+++ b/src/public/js/phpug
@@ -1,1 +1,0 @@
-../../module/Phpug/public/js

--- a/src/public/lib/phpug
+++ b/src/public/lib/phpug
@@ -1,1 +1,0 @@
-../../module/Phpug/public/lib

--- a/src/public/proxy.php
+++ b/src/public/proxy.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Copyright (c)2013-2013 Andreas Heigl<andreas@heigl.org>
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIBILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @category 
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright ©2013-2013 Andreas Heigl
+ * @license   http://www.opesource.org/licenses/mit-license.php MIT-License
+ * @version   0.0
+ * @since     03.06.13
+ * @link      https://github.com/php_ug/php_ug
+ */
+
+$mapping = array(
+    'phpug' => '../src/module/Phpug',
+    'orgheiglcontact' => 'org_heigl/contact',
+    'orgheiglmailproxy' => 'org_heigl/mailproxy',
+
+);
+
+$mimeMapping = array(
+    'js'    => 'text/javascript',
+    'img'   => 'auto',
+    'css'   => 'text/css',
+    'fonts' => 'auto',
+    'lib'   => 'auto',
+);
+
+$allowedBasePath = '/Volumes/Sites/Sites/php.ug';
+$allowedPaths = array(
+    'vendor/org_heigl/contact/public',
+    'vendor/org_heigl/mailproxy/public',
+    'src/module/Phpug/public',
+);
+
+$endMapping = array(
+    'js' => 'text/javascript',
+    'css' => 'text/css',
+    'svg' => 'application/svg+xml'
+);
+
+$filepath = __DIR__
+          . DIRECTORY_SEPARATOR
+          . '..'
+          . DIRECTORY_SEPARATOR
+          . '..'
+          . DIRECTORY_SEPARATOR
+          . 'vendor'
+          . DIRECTORY_SEPARATOR
+          . '%1$s'
+          . DIRECTORY_SEPARATOR
+          . 'public'
+          . DIRECTORY_SEPARATOR
+          . '%2$s'
+          . DIRECTORY_SEPARATOR
+          . '%3$s'
+    ;
+$realpath = sprintf($filepath, $mapping[$_REQUEST['module']], $_REQUEST['type'], $_REQUEST['file']);
+$realpath = realpath($realpath);
+
+// Filter out hidden files
+if (0 === strpos(basename($realpath), '.')) {
+    header('HTTP/1.1 404 File Not Found');
+    echo 'This is not the page you were looking for';
+    exit;
+}
+
+// Filter out not existing files
+if (! $realpath) {
+    header('HTTP/1.1 404 File Not Found');
+    echo 'This is not the page you were looking for';
+    exit;
+}
+
+// Filter out files not in one of the allowed paths
+$allowed = false;
+foreach ($allowedPaths as $allowedPath) {
+    if (0 === strpos($realpath, $allowedBasePath . DIRECTORY_SEPARATOR . $allowedPath)) {
+        $allowed = true;
+        break;
+    }
+}
+if ($allowed === false) {
+    header('HTTP/1.1 404 File Not Found');
+    echo 'Who\'s that naughty boy? That request has been logged!';
+    exit;
+}
+
+// Get the mime-type of the requestet file
+$mimeType = $mimeMapping[$_REQUEST['type']];
+$ending = substr($realpath, strrpos($realpath, '.')+1);
+if (isset($endMapping[$ending])) {
+    $mimeType = $endMapping[$ending];
+}
+if ('auto' === $mimeType) {
+    $mime = new finfo(FILEINFO_MIME);
+    $mimeType = $mime->file($realpath);
+}
+//    echo '/*-' . $mimeType . '--*/';
+
+header('Content-Type: ' . $mimeType);
+readfile($realpath);
+
+


### PR DESCRIPTION
The proxy script allows loading of files out of directories not in the
document-root. This way includable files can be loaded from everywhere
on the filesystem as long as the containing folder has been allowed.

That way includable files from any module will not have to be copied to
a public directory but will be served directly out of their
module-folder
