### PR TITLE
(re)adds subdomain routing

### DIFF
--- a/src/module/Phpug/config/module.config.php
+++ b/src/module/Phpug/config/module.config.php
@@ -157,7 +157,17 @@ return array(
                             ),
                         ),
 					),					
-				),
+                ),
+                'subdomain' => array(
+                    'type' => 'Hostname',
+                    'options' => array(
+                        'route' => ':ugid.php.ug',
+                        'defaults' => array(
+                            'controller' => 'Phpug\Controller\IndexController',
+                            'action' => 'redirect',
+                        ),
+                    ),
+                ),
  			),
 		),
 		'service_manager' => array(


### PR DESCRIPTION
The subdomain routing was broken. Terhefore that part of the routing has
been removed. Now it works again.
