### PR TITLE
Adds a way to cache UG-calendars

### DIFF
--- a/src/module/Phpug/Module.php
+++ b/src/module/Phpug/Module.php
@@ -131,6 +131,7 @@ class Module implements ConsoleUsageProviderInterface
             'getmentoring' => 'Get a list of all users of PHP-Mentoring',
             'getjoindin'   => 'Get a list of events from joind.in',
             'gettwitter'   => 'Get more information for twitter-nicks',
+            'getcalendars' => 'Fill the cache with the calendars of registered usergroups',
         );
     }
 }

--- a/src/module/Phpug/config/module.config.php
+++ b/src/module/Phpug/config/module.config.php
@@ -292,6 +292,16 @@ return array(
                         ),
                     ),
                 ),
+                'getcalendars' => array(
+                    'options' => array(
+                        'route' => 'getcalendars',
+                        'defaults' => array(
+                            '__NAMESPACE__' => 'Phpug\Controller',
+                            'controller'    => 'CalendarController',
+                            'action'        => 'getcalendars',
+                        ),
+                    ),
+                ),
             )
         )
     ),
@@ -401,6 +411,7 @@ return array(
             'Phpug\Api\Rest\Usergroup' => 'Phpug\Api\Rest\UsergroupController',
             'Phpug\Api\Rest\Twitter' => 'Phpug\Api\Rest\TwitterController',
             'Phpug\Api\v1\Usergroup' => 'Phpug\Api\v1\UsergroupController',
+            'Phpug\Controller\CalendarController' => 'Phpug\Controller\CalendarController',
             'Phpug\Controller\MentoringController' => 'Phpug\Controller\MentoringController',
             'Phpug\Controller\EventCacheController' => 'Phpug\Controller\EventCacheController',
             'Phpug\Controller\TwitterController'    => 'Phpug\Controller\TwitterController',

--- a/src/module/Phpug/src/Phpug/Controller/CalendarController.php
+++ b/src/module/Phpug/src/Phpug/Controller/CalendarController.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright (c)2014-2014 heiglandreas
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIBILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @category 
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright ©2014-2014 Andreas Heigl
+ * @license   http://www.opesource.org/licenses/mit-license.php MIT-License
+ * @version   0.0
+ * @since     13.05.14
+ * @link      https://github.com/heiglandreas/
+ */
+
+namespace Phpug\Controller;
+
+use Phpug\Parser\Mentoring;
+use Zend\Json\Json;
+use Zend\Mvc\Controller\AbstractActionController;
+use Zend\View\Model\JsonModel;
+
+class CalendarController extends AbstractActionController
+{
+
+    public function getcalendarsAction()
+    {
+        echo sprintf('Getting calendars' . "\n");
+
+        $em = $this->getServiceLocator()->get('doctrine.entitymanager.orm_default');
+
+        $q = $em->createQuery('SELECT u FROM Phpug\Entity\Usergroup u WHERE u.icalendar_url IS NOT NULL');
+
+        $result = $q->getResult();
+
+        /** @var \Phpug\Entity\Usergroup $usergroup */
+        $i = 0;
+        foreach ($q->getResult() as $usergroup) {
+            $eventCache = null;
+            /** @var \Phpug\Entity\Cache $cache */
+            $caches = $usergroup->getCaches();
+            foreach ($caches as $cache) {
+                if ($cache->type == 'event') {
+                    $eventCache = $cache;
+                    break;
+                }
+            }
+            if (! $eventCache instanceof \Phpug\Entity\Cache) {
+                $eventCache = new \Phpug\Entity\Cache();
+                $eventCache->type = 'event';
+                $usergroup->addCaches(new \Doctrine\Common\Collections\ArrayCollection(array($eventCache)));
+            }
+            set_time_limit(30);
+            $icalendar = @file_get_contents($usergroup->icalendar_url);
+            $eventCache->cache = $icalendar;
+            $eventCache->lastChangeDate = new \DateTime();
+            echo '.';
+            $em->persist($usergroup);
+            $em->flush();
+            $i++;
+        }
+
+        echo sprintf("\n" . 'Updated caches for %s usergroups' . "\n", $i);
+
+    }
+}


### PR DESCRIPTION
This PR creates a shell-script to fetch calendars for usergroups
that have a calendar enabled. Those calendars will be written into the
cache-table of the database
