### PR TITLE
Adds links to the slack-channel

### DIFF
--- a/src/module/Phpug/config/module.config.php
+++ b/src/module/Phpug/config/module.config.php
@@ -373,6 +373,21 @@ return array(
                 'label' => 'About',
                 'route' => 'ug/about',
             ),
+            array(
+                'label' => 'Slack',
+                'uri'   => 'https://phpug.slack.com',
+                'pages' => array(
+                    array(
+                        'label' => 'Usergroup-Team',
+                        'uri'   => 'https://phpug.slack.com',
+                    ),
+                    array(
+                        'label' => 'Get an Invitation',
+                        'uri'   => 'http://murmuring-forest-7062.herokuapp.com',
+                    )
+                ),
+            ),
+
         ),
     ),
     'service_manager' => array(


### PR DESCRIPTION
This PR adds a link to the slack-channel as well as to the invitation-page on heroku to the footer