### PR TITLE
Feature/allow promotion without login

### DIFF
--- a/src/module/Phpug/config/module.config.php
+++ b/src/module/Phpug/config/module.config.php
@@ -368,10 +368,10 @@ return array(
                 ),
             ),
             array(
-                'label' => 'Promote',
+                'label' => 'Include your Usergroup',
                 'route' => 'ug/promote',
-                'resource' => 'ug',
-                'privilege' => 'promote',
+//                'resource' => 'ug',
+//                'privilege' => 'promote',
             )
         ),
         'footer' => array(

--- a/src/module/Phpug/src/Phpug/Controller/UsergroupController.php
+++ b/src/module/Phpug/src/Phpug/Controller/UsergroupController.php
@@ -85,26 +85,26 @@ class UsergroupController extends AbstractActionController
     public function promoteAction()
     {
         $currentUser = $this->getServiceLocator()->get('OrgHeiglHybridAuthToken');
-        if (! $currentUser->isAuthenticated()) {
-            throw new UnauthenticatedException(
-                'You have to log in to promote a new usergroup.',
-                0,
-                null,
-                'You are not logged in'
-            );
-        }
+//        if (! $currentUser->isAuthenticated()) {
+//            throw new UnauthenticatedException(
+//                'You have to log in to promote a new usergroup.',
+//                0,
+//                null,
+//                'You are not logged in'
+//            );
+//        }
 
         $acl = $this->getServiceLocator()->get('acl');
 
         $role = $this->getServiceLocator()->get('roleManager')->setUserToken($currentUser);
-        if (! $acl->isAllowed((string) $role, 'ug', 'promote')) {
-            throw new UnauthorizedException(
-                'Your account has not the necessary rights to promote a new usergroup. If you feel like that is an error please contact us!',
-                0,
-                null,
-                'You are not authorized to do that'
-            );
-        }
+//        if (! $acl->isAllowed((string) $role, 'ug', 'promote')) {
+//            throw new UnauthorizedException(
+//                'Your account has not the necessary rights to promote a new usergroup. If you feel like that is an error please contact us!',
+//                0,
+//                null,
+//                'You are not authorized to do that'
+//            );
+//        }
 
         $form = $this->getServiceLocator()->get('PromoteUsergroupForm');
         $form->get('userGroupFieldset')->remove('id');

--- a/src/module/Phpug/src/Phpug/Controller/UsergroupController.php
+++ b/src/module/Phpug/src/Phpug/Controller/UsergroupController.php
@@ -122,6 +122,13 @@ class UsergroupController extends AbstractActionController
             $form->get('userGroupFieldset')->remove('state');
         }
 
+        if ($currentUser->isAuthenticated()) {
+            $collection = $form->get('userGroupFieldset')->get('contacts');
+            $fieldSets  = $collection->getFieldsets();
+            $fieldSets[0]->get('service')->setValue(1);
+            $fieldSets[0]->get('name')->setValue($currentUser->getName());
+        }
+
         $request = $this->getRequest();
         if ($request->isPost()) {
             // Handle form sending

--- a/src/module/Phpug/src/Phpug/Controller/UsergroupController.php
+++ b/src/module/Phpug/src/Phpug/Controller/UsergroupController.php
@@ -85,26 +85,10 @@ class UsergroupController extends AbstractActionController
     public function promoteAction()
     {
         $currentUser = $this->getServiceLocator()->get('OrgHeiglHybridAuthToken');
-//        if (! $currentUser->isAuthenticated()) {
-//            throw new UnauthenticatedException(
-//                'You have to log in to promote a new usergroup.',
-//                0,
-//                null,
-//                'You are not logged in'
-//            );
-//        }
 
         $acl = $this->getServiceLocator()->get('acl');
 
         $role = $this->getServiceLocator()->get('roleManager')->setUserToken($currentUser);
-//        if (! $acl->isAllowed((string) $role, 'ug', 'promote')) {
-//            throw new UnauthorizedException(
-//                'Your account has not the necessary rights to promote a new usergroup. If you feel like that is an error please contact us!',
-//                0,
-//                null,
-//                'You are not authorized to do that'
-//            );
-//        }
 
         $form = $this->getServiceLocator()->get('PromoteUsergroupForm');
         $form->get('userGroupFieldset')->remove('id');

--- a/src/module/Phpug/src/Phpug/Entity/Usergroup.php
+++ b/src/module/Phpug/src/Phpug/Entity/Usergroup.php
@@ -56,6 +56,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @property double $longitude
  * @property int    $ugtype
  * @property int    $state
+ * @property string $adminMail
  */
 class Usergroup
 {
@@ -126,6 +127,11 @@ class Usergroup
     protected $inputFilter;
 
     /**
+     * @ORM\Column(type="string")
+     */
+    protected $adminMail;
+
+    /**
     * Magic getter to expose protected properties.
     *
     * @param string $property
@@ -160,6 +166,7 @@ class Usergroup
             'latitude'      => $this->getLatitude(),
             'longitude'     => $this->getLongitude(),
             'state'         => $this->getState(),
+            'adminMail'     => $this->getAdminMail(),
             'contacts'      => array(),
             'ugtype'        => array(
                 'id'          => $this->ugtype->getId(),
@@ -514,6 +521,30 @@ class Usergroup
         }
 
         return true;
+    }
+
+    /**
+     * Set an administrative contact
+     *
+     * @param string $contact
+     *
+     * @return self
+     */
+    public function setAdminMail($contact)
+    {
+        $this->adminMail = $contact;
+
+        return $this;
+    }
+
+    /**
+     * Get the administrative contact
+     *
+     * @return string
+     */
+    public function getAdminMail()
+    {
+        return $this->adminMail;
     }
 
 }

--- a/src/module/Phpug/src/Phpug/Form/UsergroupFieldset.php
+++ b/src/module/Phpug/src/Phpug/Form/UsergroupFieldset.php
@@ -148,6 +148,18 @@ class UsergroupFieldset extends Fieldset implements InputFilterProviderInterface
         ));
 
         $this->add(array(
+            'type' => 'Zend\Form\Element\Email',
+            'name' => 'adminMail',
+            'options' => array(
+                'label' => 'Admin-Contact',
+                'label_attributes' => array(
+                    'class' => 'control-label',
+                ),
+                'description' => 'How can the PHP.ug-admins contact you in case there are any questions? This address will NOT be publicly displayed, it\'s just for administrative purposes!',
+            ),
+        ));
+
+        $this->add(array(
             'type' => 'Zend\Form\Element\Select',
             'name' => 'state',
             'options' => array(
@@ -274,9 +286,15 @@ class UsergroupFieldset extends Fieldset implements InputFilterProviderInterface
             'ugtype' => array(
                 'required' => true,
             ),
-//            'state' => array(
-//                'required' => true,
-//            ),
+            'adminMail' => array(
+                'required' => true,
+                'validators' => [array(
+                    'name' => 'EmailAddress',
+                    'options' => array(
+                        'hostnameValidator' => new Validator\Hostname(),
+                    ),
+                )],
+            ),
         );
     }
 

--- a/src/module/Phpug/src/Phpug/Form/UsergroupFieldset.php
+++ b/src/module/Phpug/src/Phpug/Form/UsergroupFieldset.php
@@ -150,8 +150,11 @@ class UsergroupFieldset extends Fieldset implements InputFilterProviderInterface
         $this->add(array(
             'type' => 'Zend\Form\Element\Email',
             'name' => 'adminMail',
+            'attributes' => array(
+                'placeholder' => 'admin@example.org',
+            ),
             'options' => array(
-                'label' => 'Admin-Contact',
+                'label' => 'Admin-Email',
                 'label_attributes' => array(
                     'class' => 'control-label',
                 ),

--- a/src/module/Phpug/view/phpug/promote/index.phtml
+++ b/src/module/Phpug/view/phpug/promote/index.phtml
@@ -1,5 +1,5 @@
 <?php
-$this->headTitle('Promote your UserGroup');
+$this->headTitle('Include your UserGroup');
 
 echo $this->form()->openTag($form);
 $label = $this->plugin('formLabel');

--- a/src/module/Phpug/view/phpug/usergroup/promote.phtml
+++ b/src/module/Phpug/view/phpug/usergroup/promote.phtml
@@ -2,7 +2,7 @@
 
 $form->prepare();
 
-$this->headTitle('Promote your UserGroup');
+$this->headTitle('Include your UserGroup');
 
 $form->setAttribute('class', 'form-horizontal');
 if ($form->getMessages()) {


### PR DESCRIPTION
This PR adds the possibility to add a usergroup without the need to login. When you are logged in the currently logged in user is added as first contact of the usergroup. 

Additionally an administrative Email-address has to be given for new and existing groups.

Fixes #107 