### PR TITLE
add tags to groups

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
     "jbox": "~0.3.2",
     "html5shiv": "~3.7.2",
     "jquery-cookie": "~1.4.1",
-    "Leaflet.label": "~0.2.1"
+    "Leaflet.label": "~0.2.1",
+    "chosen": "~1.4.2"
   }
 }

--- a/src/module/Phpug/public/js/phpug.js
+++ b/src/module/Phpug/public/js/phpug.js
@@ -189,15 +189,31 @@ var phpug = L.layerJSON({
                 + '</h4>'
                 + '<h5>Next Event</h5>'
                 + '<div id="next_event_%shortname%" class="next_event">Getting next event...</div>'
+                + '%interests%'
                 + '<h5>Get in touch</h5>'
                 + '%contacts%'
                 + '</div>'
             ;
 
+        var interest = '<li class="label label-primary">%interest%</li>';
+        var interests = [];
+
         var contact = '<a href="%url%" title="%value%" target="_blank">'
             + '<i class="%cssClass%"></i>'
             + '</a>';
         var contacts = [];
+
+        for (i in data.tags){
+            interests.push(
+                interest.replace(/%interest%/, data.tags[i].name)
+            );
+        }
+        interestString = '';
+        if (interests.length > 0) {
+            interestString = '<h5 style="margin-bottom:0;">Interests</h5><ul>'
+                + interests.join("\n")
+                + '</ul>';
+        }
 
         if (data.icalendar_url) {
             contacts.push(
@@ -228,7 +244,9 @@ var phpug = L.layerJSON({
         content = content.replace(/%url%/, data.url)
             .replace(/%name%/, data.name)
             .replace(/%shortname%/, data.shortname)
-            .replace(/%contacts%/, contacts);
+            .replace(/%contacts%/, contacts)
+            .replace(/%interests%/, interestString)
+        ;
 
         if (center && center === data.shortname){
             map.setView(new L.LatLng(data.latitude,data.longitude), 8);

--- a/src/module/Phpug/src/Phpug/Entity/Tag.php
+++ b/src/module/Phpug/src/Phpug/Entity/Tag.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Copyright (c) 2011-2012 Andreas Heigl<andreas@heigl.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @category  php.ug
+ * @package   Phpug
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright 2011-2012 php.ug
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @version   0.0
+ * @since     05.12.2012
+ * @link      http://github.com/heiglandreas/php.ug
+ */
+
+namespace Phpug\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * The Persistent-Storage Entity
+ *
+ * @category  php.ug
+ * @package   Phpug
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright 2011-2012 php.ug
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @version   0.0
+ * @since     19.08.2015
+ * @link      http://github.com/heiglandreas/php.ug
+ * @ORM\Entity
+ * @ORM\Table(name="tag")
+ * @property string $tagname
+ * @property text $description
+ */
+class Tag
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer");
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    protected $tagname;
+
+    /**
+     * @ORM\Column(type="text")
+     */
+    protected $description;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="Usergroup", mappedBy="tags")
+     * @var \Doctrine\Common\Collections\ArrayCollection $usergroups
+     */
+    protected $usergroups;
+
+    public function __construct()
+    {
+        $this->usergroups = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+    /**
+    * Magic getter to expose protected properties.
+    *
+    * @param string $property
+    * @return mixed
+    */
+    public function __get($property) {
+        return $this->$property;
+    }
+
+    /**
+     * Magic setter to save protected properties.
+     *
+     * @param string $property
+     * @param mixed $value
+     */
+    public function __set($property, $value) {
+        $this->$property = $value;
+    }
+
+    /**
+     * Convert the object to an array.
+     *
+     * @return array
+     */
+    public function toArray() {
+        return array();
+    }
+
+    /**
+     * Set the tagname for this Object
+     *
+     * @param string $tagname
+     *
+     * @return self
+     */
+    public function setTagname($tagname)
+    {
+        $this->tagname = $tagname;
+
+        return $this;
+    }
+
+    /**
+     * Get the name of this tag
+     *
+     * @return string
+     */
+    public function getTagname()
+    {
+        return $this->tagname;
+    }
+
+    /**
+     * Set the description of this tag
+     *
+     * @param string $description
+     *
+     * @return self
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Get the description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * add a group to this tag
+     *
+     * @param Usergroup $group
+     *
+     * @return self
+     */
+    public function addGroup(Usergroup $group)
+    {
+        $this->usergroups->add($group);
+
+        return $this;
+    }
+
+    /**
+     * Remove the usergroup from this entry
+     *
+     * @param Usergroup $group
+     *
+     * @return self
+     */
+    public function removeGroup(Usergroup $group)
+    {
+
+        $this->usergroups->removeElement($group);
+
+        return $this;
+    }
+
+    /**
+     * Get all groups for this tag
+     *
+     * @return Usergroup[]
+     */
+    public function getGroups()
+    {
+        return $this->usergroups->toArray();
+    }
+
+}

--- a/src/module/Phpug/src/Phpug/Entity/Usergroup.php
+++ b/src/module/Phpug/src/Phpug/Entity/Usergroup.php
@@ -189,6 +189,13 @@ class Usergroup
             );
         }
 
+        foreach ($this->tags as $tag) {
+            $return['tags'][] = array(
+                'name' => $tag->getTagname(),
+                'description' => $tag->getDescription(),
+            );
+        }
+
         return $return;
     }
     

--- a/src/module/Phpug/src/Phpug/Entity/Usergroup.php
+++ b/src/module/Phpug/src/Phpug/Entity/Usergroup.php
@@ -132,6 +132,12 @@ class Usergroup
     protected $adminMail;
 
     /**
+     * @ORM\ManyToMany(targetEntity="Tag", inversedBy="usergroups")
+     * @ORM\JoinTable(name="usergroups_tags")
+     */
+    protected $tags;
+
+    /**
     * Magic getter to expose protected properties.
     *
     * @param string $property
@@ -190,6 +196,7 @@ class Usergroup
     {
         $this->contacts = new ArrayCollection();
         $this->caches   = new ArrayCollection();
+        $this->tags     = new ArrayCollection();
     }
 
     /**
@@ -545,5 +552,78 @@ class Usergroup
     {
         return $this->adminMail;
     }
+
+    /**
+     * Add a tag
+     *
+     * @param Tag $tag
+     *
+     * @return self
+     */
+    public function addTag(Tag $tag)
+    {
+        $tag->addGroup($this);
+        $this->tags->add($tag);
+
+        return $this;
+    }
+
+    /**
+     * Remove a tag
+     *
+     * @param Tag $tag
+     *
+     * @return self
+     */
+    public function removeTag(Tag $tag)
+    {
+        $tag->removeGroup($this);
+        $this->tags->removeElement($tag);
+
+        return $this;
+    }
+
+    /**
+     * Get a list of all Tags
+     *
+     * @return Tag[]
+     */
+    public function getTags()
+    {
+        return $this->tags->toArray();
+    }
+
+    /**
+     * Set the given tags
+     *
+     * @param ArrayCollection $tags
+     *
+     * @return self
+     */
+    public function addTags(ArrayCollection $tags)
+    {
+        foreach ($tags as $tag) {
+            $this->addTag($tag);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove a set of tags
+     * 
+     * @param ArrayCollection $tags
+     *
+     * @return self
+     */
+    public function removeTags(ArrayCollection $tags)
+    {
+        foreach ($tags as $tag) {
+            $this->removeTag($tags);
+        }
+
+        return $this;
+    }
+
 
 }

--- a/src/module/Phpug/src/Phpug/Form/UsergroupFieldset.php
+++ b/src/module/Phpug/src/Phpug/Form/UsergroupFieldset.php
@@ -148,6 +148,30 @@ class UsergroupFieldset extends Fieldset implements InputFilterProviderInterface
         ));
 
         $this->add(array(
+            'type' => 'DoctrineModule\Form\Element\ObjectSelect',
+            'name' => 'tags',
+            'attributes' => array(
+                'multiple' => true,
+            ),
+            'options' => array(
+                'label' => 'Tags',
+                'label_attributes' => array(
+                    'class' => 'control-label'
+                ),
+                'description' => 'What is of interest to your usergroup',
+                'object_manager' => $em,
+                'target_class' => 'Phpug\Entity\Tag',
+                'property' => 'tagname',
+                'is_method' => true,
+                'find_method' => array(
+                    'name' => 'findAll',
+                    'params' => array(),
+                ),
+            ),
+
+        ));
+
+        $this->add(array(
             'type' => 'Zend\Form\Element\Email',
             'name' => 'adminMail',
             'attributes' => array(

--- a/src/module/Phpug/view/phpug/usergroup/promote.phtml
+++ b/src/module/Phpug/view/phpug/usergroup/promote.phtml
@@ -3,6 +3,9 @@
 $form->prepare();
 
 $this->headTitle('Include your UserGroup');
+$this->headScript()->prependFile('/lib/chosen/chosen.jquery.min.js');
+$this->headLink()->appendStylesheet('/lib/chosen/chosen.min.css');
+
 
 $form->setAttribute('class', 'form-horizontal');
 if ($form->getMessages()) {
@@ -82,4 +85,6 @@ $this->headScript()->appendScript("
         $(e.target).popover('hide');
     });
     $('[data-toggle=tooltip]').tooltip({container:'body'});
+
+    $('select[multiple=multiple]').chosen();
 ");


### PR DESCRIPTION
This PR allows to add tags to groups to categorize what interests the group has. 

That way usergroups that concentrate more on one specific part of the PHP-Community can be included on the map as well.

In a future PR those tags can be used to toggle display of the markers on the map.

This fixes #127 