### PR TITLE
Fixes issue with google-calendar validation

### DIFF
--- a/src/module/Phpug/src/Phpug/Validator/IsCalendarUrl.php
+++ b/src/module/Phpug/src/Phpug/Validator/IsCalendarUrl.php
@@ -53,7 +53,7 @@ class IsCalendarUrl extends AbstractValidator
     protected function getHeaders($url)
     {
         $ch = curl_init($url);
-        curl_setopt($ch, CURLOPT_NOBODY, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_USERAGENT, "php.ug-website-checker");
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
         curl_exec($ch);


### PR DESCRIPTION
Google-Calendar doesn't implement the HTPP-Verb HEAD and therefore
validation of a calendar-URL fails when a google-calendar is provided.

This Commit instead uses the default GET-method to check for details
about the calendar and therefore also works with google-calendar.

Currently tested: Google, Meetup and Wordpress' Event-Plugin