### PR TITLE
Changed maximum length of shortname to 25 characters.

### DIFF
--- a/src/module/Phpug/src/Phpug/Form/UsergroupFieldset.php
+++ b/src/module/Phpug/src/Phpug/Form/UsergroupFieldset.php
@@ -253,7 +253,7 @@ class UsergroupFieldset extends Fieldset implements InputFilterProviderInterface
                         'options' => array(
                             'encoding' => 'UTF-8',
                             'min'      => 2,
-                            'max'      => 10,
+                            'max'      => 25,
                         ),
                     ),
                     array(


### PR DESCRIPTION
Resolves Issue #148.