### PR TITLE
Fixes the link to the phpmentoring-app

### DIFF
--- a/src/module/Phpug/public/js/phpug.js
+++ b/src/module/Phpug/public/js/phpug.js
@@ -349,7 +349,7 @@ var mentoringapp = L.layerJSON({
     propertyLoc : ['lat', 'lon'],
     propertyTitle : 'name',
     buildPopup : function(data){
-        url = 'http://app.phpmentoring.org/profile/';
+        url = 'https://php-mentoring.org/profile/';
         content = '<div class="popup">'
             + '<h4>'
             + '<a href="%url%" target="_blank">'


### PR DESCRIPTION
This was necessary due to php-mentoring moving to a different domain.