### PR TITLE
Allow to filter tags by Query-Parameter "tag"

### DIFF
--- a/src/module/Phpug/public/js/phpug.js
+++ b/src/module/Phpug/public/js/phpug.js
@@ -476,6 +476,13 @@ if(false !== loc) {
     },{timeout:3000});
 }
 
+var tag=getQueryParameter('tag');
+if (tag) {
+    $('#ugtags').val(tag)
+        .trigger('chosen:updated')
+        .trigger('change');
+}
+
 map.setView(coord, zoom)
    .addLayer(openstreetmap);
 


### PR DESCRIPTION
This will enable the possibility to select usergroups with only a
certain tag by appending "tag=<tagname>" as a query-parameter to the
URI. The Tags have to be writen in the same case as they are in the
multi-select field.